### PR TITLE
replace last net/context with core context

### DIFF
--- a/operation/command/property.go
+++ b/operation/command/property.go
@@ -243,7 +243,7 @@ func (contextConf *CommandContextProperty) Label() string {
 
 // Description for the Property
 func (contextConf *CommandContextProperty) Description() string {
-	return "A golang.org/x/net/context for controling execution."
+	return "A context for controling execution."
 }
 
 // Is the Property internal only

--- a/operation/property_base.go
+++ b/operation/property_base.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"os"
 
-	"golang.org/x/net/context"
+	"context"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -227,7 +227,7 @@ type ContextProperty struct {
 
 // Give an idea of what type of value the property consumes
 func (property *ContextProperty) Type() string {
-	return "golang.org/x/net/context.Context"
+	return "context.Context"
 }
 
 // Retrieve the context, or retrieve a Background context by default
@@ -243,7 +243,7 @@ func (property *ContextProperty) Set(value interface{}) bool {
 		property.value = converted
 		return true
 	} else {
-		log.WithFields(log.Fields{"value": value}).Error("Could not assign Property value, because the passed parameter was the wrong type. Expected golang.org/x/net/context/Context")
+		log.WithFields(log.Fields{"value": value}).Error("Could not assign Property value, because the passed parameter was the wrong type. Expected context/Context")
 		return false
 	}
 }


### PR DESCRIPTION
the two libraries present identical interfaces, and are therefore compatible in our use, but the core library requires no real dependencies.