### PR TITLE
many security operations go internal()

### DIFF
--- a/operation/security/authorize.go
+++ b/operation/security/authorize.go
@@ -32,5 +32,5 @@ func (authorize *BaseSecurityAuthorizeOperation) Description() string {
 
 // Is this an internal API operation
 func (authorize *BaseSecurityAuthorizeOperation) Internal() bool {
-	return false
+	return true
 }

--- a/operation/security/property.go
+++ b/operation/security/property.go
@@ -65,7 +65,7 @@ func (authSuccessProp *SecurityAuthorizationSucceededProperty) Description() str
 
 // Mark a property as being for internal use only (no shown to users)
 func (authSuccessProp *SecurityAuthorizationSucceededProperty) Internal() bool {
-	return false
+	return true
 }
 
 // An Operation property
@@ -90,7 +90,7 @@ func (operationProp *SecurityAuthorizationOperationProperty) Description() strin
 
 // Mark a property as being for internal use only (no shown to users)
 func (operationProp *SecurityAuthorizationOperationProperty) Internal() bool {
-	return false
+	return true
 }
 
 // An Operation property
@@ -159,7 +159,7 @@ func (userProp *SecurityUserProperty) Description() string {
 
 // Mark a property as being for internal use only (no shown to users)
 func (userProp *SecurityUserProperty) Internal() bool {
-	return false
+	return true
 }
 
 // Give an idea of what type of value the property consumes

--- a/operation/security/user.go
+++ b/operation/security/user.go
@@ -56,5 +56,5 @@ func (authenticate *BaseSecurityUserOperation) Description() string {
 
 // Is this an internal API operation
 func (authenticate *BaseSecurityUserOperation) Internal() bool {
-	return false
+	return true
 }


### PR DESCRIPTION
This patch takes many of the security operations internal, so that they are not shown to default consumers.

Most of these operations are only used internally.  Their public use was really just demonstrative.
Most properties are only set internally, but it was nice to have some of them output in the CLI (like auth.success)

This can be restored if the approach is changes at the consumer end.
