### PR TITLE
Fallback security user

### DIFF
--- a/operation/config/connector_simple.go
+++ b/operation/config/connector_simple.go
@@ -36,12 +36,11 @@ func (readers ConfigSimpleConnectorReadersOperation) Exec(props *operation.Prope
 	readersProp, _ := props.Get(OPERATION_PROPERTY_CONFIG_VALUE_READERS)
 
 	if key, ok := keyProp.Get().(string); ok && key != "" {
-		if readersValue := readers.Connector().Readers(key); len(readersValue.Order()) > 0 {
-			readersProp.Set(readersValue)
-			result.MarkSuccess()
-		} else {
-			result.AddError(errors.New("Unknown config key requested"))
-			result.MarkFailed()
+		readersValue := readers.Connector().Readers(key)
+		readersProp.Set(readersValue)
+		result.MarkSuccess()
+		if len(readersValue.Order()) == 0 {
+			result.AddError(errors.New("No config found for requested key"))
 		}
 	} else {
 		result.AddError(errors.New("Invalid config key requested"))

--- a/operation/property_decorator.go
+++ b/operation/property_decorator.go
@@ -38,7 +38,7 @@ func (decProp *DecoratingInternalizerProperty) Description() string {
 
 // Mark a property as being for internal use only (no shown to users)
 func (decProp *DecoratingInternalizerProperty) Internal() bool {
-	return false
+	return true
 }
 
 // Give an idea of what type of value the property consumes

--- a/operation/security/property.go
+++ b/operation/security/property.go
@@ -40,7 +40,7 @@ func (authSuccessProp *SecurityAuthenticationSucceededProperty) Description() st
 
 // Mark a property as being for internal use only (no shown to users)
 func (authSuccessProp *SecurityAuthenticationSucceededProperty) Internal() bool {
-	return false
+	return true
 }
 
 // A boolean property for if an authorization succeeded (was granted)
@@ -115,7 +115,7 @@ func (ruleresultProp *SecurityAuthorizationRuleResultProperty) Description() str
 
 // Mark a property as being for internal use only (no shown to users)
 func (ruleresultProp *SecurityAuthorizationRuleResultProperty) Internal() bool {
-	return false
+	return true
 }
 
 // Give an idea of what type of value the property consumes

--- a/operation/security/user.go
+++ b/operation/security/user.go
@@ -1,5 +1,9 @@
 package security
 
+import (
+	"os/user"
+)
+
 /**
  * User retrieval related functionality
  */
@@ -29,6 +33,36 @@ type SecurityUser interface {
 	 * like RSA passphrase or password entry.
 	 */
 	// Authenticate(AuthenticationChallenge) AuthenticationResponse
+}
+
+/**
+ * A SecurityUser implementation that wraps the 
+ * core os/user.User object
+ */
+type CoreUserSecurityUser struct {
+	user *user.User
+}
+
+// Constructor for CoreUserSecurityUser
+func New_CoreUserSecurityUser(coreUser *user.User) *CoreUserSecurityUser {
+	return &CoreUserSecurityUser{
+		user: coreUser,
+	}
+}
+
+// Return this object as a SecurityUser interface
+func (coreUser *CoreUserSecurityUser) SecurityUser() SecurityUser {
+	return SecurityUser(coreUser)
+}
+
+// Return a machine id for the user for things like authorization checks
+func (coreUser *CoreUserSecurityUser) Id() string {
+	return coreUser.user.Username
+}
+
+// Human readable display id for the user
+func (coreUser *CoreUserSecurityUser) Label() string {
+	return coreUser.user.Name
 }
 
 /**


### PR DESCRIPTION
Create the architecture to use a core golang os/user.User as a SecurityUser, so that we can have an OS safe fallback user for security user assignment.

Also fixed:
1. InternalizerDecoratorProperty now properly marks decorated properties as Internal() [duh!]
2. Marked some other properties as internal, which were previously external.

@NOTE it would be handy to have some properties marked as "externally read only" so that we can know to output them, but not to accept values for them.