### PR TITLE
fix missing prop in settings list operation

### DIFF
--- a/operation/config/list.go
+++ b/operation/config/list.go
@@ -47,6 +47,10 @@ func (list *BaseConfigListOperation) Properties() api_property.Properties {
 	props := api_property.New_SimplePropertiesEmpty()
 
 	props.Add(api_property.New_UsageDecoratedProperty(
+		api_property.Property(&ConfigKeyProperty{}),
+		api_property.Usage_ReadOnly(),
+	))
+	props.Add(api_property.New_UsageDecoratedProperty(
 		api_property.Property(&ConfigKeysProperty{}),
 		api_property.Usage_ReadOnly(),
 	))


### PR DESCRIPTION
This patch restores a removed property from one of the settings operations.  This was an internal operation that was rarely used, so the removal of the property did not trigger any test failures until recently.